### PR TITLE
Change pathfinder and edges.json file paths

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -2,11 +2,7 @@ import path from 'path';
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
-export const EDGES_DIRECTORY_NAME = 'edges-data';
-export const EDGES_FILE_PATH = path.join(
-  '..',
-  EDGES_DIRECTORY_NAME,
-  'edges.json',
-);
-
-export const PATHFINDER_FILE_PATH = path.join('..', 'pathfinder');
+export const BASE_PATH = path.join(__dirname, '..');
+export const EDGES_DIRECTORY_PATH = path.join(BASE_PATH, 'edges-data');
+export const EDGES_FILE_PATH = path.join(EDGES_DIRECTORY_PATH, 'edges.json');
+export const PATHFINDER_FILE_PATH = path.join(BASE_PATH, 'pathfinder');

--- a/src/services/edgesFile.js
+++ b/src/services/edgesFile.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 import web3 from './web3';
-import { EDGES_FILE_PATH, EDGES_DIRECTORY_NAME } from '../constants';
+import { EDGES_FILE_PATH, EDGES_DIRECTORY_PATH } from '../constants';
 
 const stringify = fastJsonStringify({
   title: 'Circles Edges Schema',
@@ -35,14 +35,13 @@ export async function writeToFile(
 ) {
   return new Promise((resolve, reject) => {
     // Check if `edges-data` folder exists and create it otherwise
-    const edgesDataPath = path.join('..', EDGES_DIRECTORY_NAME);
-    if (!fs.existsSync(edgesDataPath)) {
-      fs.mkdirSync(edgesDataPath);
+    if (!fs.existsSync(EDGES_DIRECTORY_PATH)) {
+      fs.mkdirSync(EDGES_DIRECTORY_PATH);
     }
 
     // Write to temporary file first
     const tmpFilePath = path.join(
-      edgesDataPath,
+      EDGES_DIRECTORY_PATH,
       `edges.json-tmp-${tmpFileKey}`,
     );
 


### PR DESCRIPTION
Seperates the `pathfinder` executable from the `edges.json` path as we need separate volumes for them in our Kubernetes setup:

* `edges.json` and the temporary files are stored now in a folder named `edges-data` (which can now easily be mounted as a persistent volume in Docker / Kubernetes without overwriting the pathfinder)
* The `pathfinder` binary sits in the root of the project