### PR TITLE
Do not wait for graph in entrypoint script but in program

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -8,29 +8,6 @@ CMD="$@"
 POSTGRES_PORT=${POSTGRES_PORT:-5432}
 NODE_ENV=${NODE_ENV:-"production"}
 
-# Helper method to extract host and port from url
-parse_url() {
-  # Extract the protocol
-  proto="$(echo $1 | grep :// | sed -e's,^\(.*://\).*,\1,g')"
-  # Remove the protocol
-  url=$(echo $1 | sed -e s,$proto,,g)
-  # Extract the host and port
-  hostport=$(echo $url | cut -d/ -f1)
-  # Extract host without port
-  host="$(echo $hostport | sed -e 's,:.*,,g')"
-  # Try to extract the port
-  port="$(echo $hostport | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')"
-  # Set port default when not given
-  if [ -z "$port" ]
-  then
-    [ "$proto" = "https://" ] && port=443 || port=80
-  fi
-  echo "$host:$port"
-}
-
-# Wait until graph node is ready
-./wait-for-it.sh "$(parse_url $GRAPH_NODE_ENDPOINT)" -t 60
-
 # Wait until database is ready
 ./wait-for-it.sh "$POSTGRES_HOST:$POSTGRES_PORT" -t 60
 

--- a/src/services/graph.js
+++ b/src/services/graph.js
@@ -84,7 +84,22 @@ export default async function fetchAllFromGraph(name, fields, extra = '') {
 }
 
 export async function waitUntilGraphIsReady() {
-  return await waitForBlockNumber(0);
+  const query = isOfficialNode()
+    ? `{ indexingStatusForCurrentVersion(subgraphName: "${process.env.SUBGRAPH_NAME}") { chains } }`
+    : '{ subgraphs { id } }';
+
+  return await loop(
+    async () => {
+      try {
+        return await fetchFromGraphStatus(query);
+      } catch {
+        return false;
+      }
+    },
+    (isOnline) => {
+      return isOnline;
+    },
+  );
 }
 
 export async function waitForBlockNumber(blockNumber) {


### PR DESCRIPTION
This fixes two issues:

* The wait-for script gets stuck on production when using the external graph node
* One does not need to write a second `make up` afterwards to restart the api, after running `make contracts`, `make subgraph` during local development