### PR TITLE
Fix negative buffer

### DIFF
--- a/src/helpers/reduce.js
+++ b/src/helpers/reduce.js
@@ -6,12 +6,15 @@ export default function reduceCapacities(
 ) {
   return edges
     .filter((edge) => {
-      return edge.capacity.length >= bufferDecimals + 1;
+      return edge.capacity.length > bufferDecimals + 1;
     })
-    .map((edge) => {
-      edge.capacity = reduceCapacity(edge.capacity, bufferDecimals);
-      return edge;
-    });
+    .reduce((acc, edge) => {
+      acc.push({
+        ...edge,
+        capacity: reduceCapacity(edge.capacity, bufferDecimals),
+      });
+      return acc;
+    }, []);
 }
 
 export function reduceCapacity(

--- a/src/helpers/reduce.js
+++ b/src/helpers/reduce.js
@@ -6,7 +6,7 @@ export default function reduceCapacities(
 ) {
   return edges
     .filter((edge) => {
-      return edge.capacity.length > bufferDecimals + 1;
+      return edge.capacity.length >= bufferDecimals + 1;
     })
     .reduce((acc, edge) => {
       acc.push({
@@ -22,7 +22,7 @@ export function reduceCapacity(
   bufferDecimals = DEFAULT_BUFFER_DECIMALS,
 ) {
   // Ignore too small values
-  if (value.length <= bufferDecimals + 1) {
+  if (value.length < bufferDecimals + 1) {
     return value;
   }
 
@@ -32,8 +32,8 @@ export function reduceCapacity(
   const figureToChange = parseInt(value[index], 10);
 
   if (figureToChange === 0) {
-    const reducedFrontNumber = parseInt(frontNumber, 10) - 1;
-    return `${reducedFrontNumber}0${endOfNumber}`;
+    const reduced = parseInt(frontNumber, 10) - 1;
+    return `${reduced === 0 ? '' : reduced}9${endOfNumber}`;
   } else {
     return `${frontNumber}${figureToChange - 1}${endOfNumber}`;
   }

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -93,70 +93,67 @@ describe('Helpers', () => {
 
   describe('reduceCapacity', () => {
     it('should reduce capacity values correctly', () => {
-      // Alias for better readability
-      const r = reduceCapacity;
+      expect(reduceCapacity('10000', 1)).toBe('9999');
+      expect(reduceCapacity('10000', 2)).toBe('9990');
+      expect(reduceCapacity('10000', 3)).toBe('9900');
+      expect(reduceCapacity('10000', 4)).toBe('9000');
 
-      expect(r('10000', 1)).toBe('9999');
-      expect(r('10000', 2)).toBe('9990');
-      expect(r('10000', 3)).toBe('9900');
-      expect(r('10000', 4)).toBe('9000');
+      expect(reduceCapacity('12345', 1)).toBe('12344');
+      expect(reduceCapacity('12345', 2)).toBe('12335');
+      expect(reduceCapacity('12345', 3)).toBe('12245');
+      expect(reduceCapacity('12345', 4)).toBe('11345');
 
-      expect(r('12345', 1)).toBe('12344');
-      expect(r('12345', 2)).toBe('12335');
-      expect(r('12345', 3)).toBe('12245');
-      expect(r('12345', 4)).toBe('11345');
+      expect(reduceCapacity('17000000000000000', 1)).toBe('16999999999999999');
+      expect(reduceCapacity('17000000000000000', 2)).toBe('16999999999999990');
+      expect(reduceCapacity('17000000000000000', 3)).toBe('16999999999999900');
+      expect(reduceCapacity('17000000000000000', 4)).toBe('16999999999999000');
+      expect(reduceCapacity('17000000000000000', 5)).toBe('16999999999990000');
+      expect(reduceCapacity('17000000000000000', 6)).toBe('16999999999900000');
+      expect(reduceCapacity('17000000000000000', 7)).toBe('16999999999000000');
+      expect(reduceCapacity('17000000000000000', 8)).toBe('16999999990000000');
+      expect(reduceCapacity('17000000000000000', 9)).toBe('16999999900000000');
+      expect(reduceCapacity('17000000000000000', 10)).toBe('16999999000000000');
+      expect(reduceCapacity('17000000000000000', 11)).toBe('16999990000000000');
+      expect(reduceCapacity('17000000000000000', 12)).toBe('16999900000000000');
+      expect(reduceCapacity('17000000000000000', 13)).toBe('16999000000000000');
+      expect(reduceCapacity('17000000000000000', 14)).toBe('16990000000000000');
+      expect(reduceCapacity('17000000000000000', 15)).toBe('16900000000000000');
+      expect(reduceCapacity('17000000000000000', 16)).toBe('16000000000000000');
 
-      expect(r('17000000000000000', 1)).toBe('16999999999999999');
-      expect(r('17000000000000000', 2)).toBe('16999999999999990');
-      expect(r('17000000000000000', 3)).toBe('16999999999999900');
-      expect(r('17000000000000000', 4)).toBe('16999999999999000');
-      expect(r('17000000000000000', 5)).toBe('16999999999990000');
-      expect(r('17000000000000000', 6)).toBe('16999999999900000');
-      expect(r('17000000000000000', 7)).toBe('16999999999000000');
-      expect(r('17000000000000000', 8)).toBe('16999999990000000');
-      expect(r('17000000000000000', 9)).toBe('16999999900000000');
-      expect(r('17000000000000000', 10)).toBe('16999999000000000');
-      expect(r('17000000000000000', 11)).toBe('16999990000000000');
-      expect(r('17000000000000000', 12)).toBe('16999900000000000');
-      expect(r('17000000000000000', 13)).toBe('16999000000000000');
-      expect(r('17000000000000000', 14)).toBe('16990000000000000');
-      expect(r('17000000000000000', 15)).toBe('16900000000000000');
-      expect(r('17000000000000000', 16)).toBe('16000000000000000');
-
-      expect(r('1094000000000012345', 1)).toBe('1094000000000012344');
-      expect(r('1094000000000012345', 2)).toBe('1094000000000012335');
-      expect(r('1094000000000012345', 3)).toBe('1094000000000012245');
-      expect(r('1094000000000012345', 4)).toBe('1094000000000011345');
-      expect(r('1094000000000012345', 5)).toBe('1094000000000002345');
-      expect(r('1094000000000012345', 6)).toBe('1093999999999912345');
-      expect(r('1094000000000012345', 7)).toBe('1093999999999012345');
-      expect(r('1094000000000012345', 8)).toBe('1093999999990012345');
-      expect(r('1094000000000012345', 9)).toBe('1093999999900012345');
-      expect(r('1094000000000012345', 10)).toBe('1093999999000012345');
-      expect(r('1094000000000012345', 11)).toBe('1093999990000012345');
-      expect(r('1094000000000012345', 12)).toBe('1093999900000012345');
-      expect(r('1094000000000012345', 13)).toBe('1093999000000012345');
-      expect(r('1094000000000012345', 14)).toBe('1093990000000012345');
-      expect(r('1094000000000012345', 15)).toBe('1093900000000012345');
-      expect(r('1094000000000012345', 16)).toBe('1093000000000012345');
-      expect(r('1094000000000012345', 17)).toBe('1084000000000012345');
-      expect(r('1094000000000012345', 18)).toBe('994000000000012345');
+      expect(reduceCapacity('1094000000000012345', 1)).toBe('1094000000000012344');
+      expect(reduceCapacity('1094000000000012345', 2)).toBe('1094000000000012335');
+      expect(reduceCapacity('1094000000000012345', 3)).toBe('1094000000000012245');
+      expect(reduceCapacity('1094000000000012345', 4)).toBe('1094000000000011345');
+      expect(reduceCapacity('1094000000000012345', 5)).toBe('1094000000000002345');
+      expect(reduceCapacity('1094000000000012345', 6)).toBe('1093999999999912345');
+      expect(reduceCapacity('1094000000000012345', 7)).toBe('1093999999999012345');
+      expect(reduceCapacity('1094000000000012345', 8)).toBe('1093999999990012345');
+      expect(reduceCapacity('1094000000000012345', 9)).toBe('1093999999900012345');
+      expect(reduceCapacity('1094000000000012345', 10)).toBe('1093999999000012345');
+      expect(reduceCapacity('1094000000000012345', 11)).toBe('1093999990000012345');
+      expect(reduceCapacity('1094000000000012345', 12)).toBe('1093999900000012345');
+      expect(reduceCapacity('1094000000000012345', 13)).toBe('1093999000000012345');
+      expect(reduceCapacity('1094000000000012345', 14)).toBe('1093990000000012345');
+      expect(reduceCapacity('1094000000000012345', 15)).toBe('1093900000000012345');
+      expect(reduceCapacity('1094000000000012345', 16)).toBe('1093000000000012345');
+      expect(reduceCapacity('1094000000000012345', 17)).toBe('1084000000000012345');
+      expect(reduceCapacity('1094000000000012345', 18)).toBe('994000000000012345');
 
       // Using default value
-      expect(r('17000000000000000')).toBe('16900000000000000');
-      expect(r('91000000000000000')).toBe('90900000000000000');
-      expect(r('9999999999999999999')).toBe('9899999999999999999');
+      expect(reduceCapacity('17000000000000000')).toBe('16900000000000000');
+      expect(reduceCapacity('91000000000000000')).toBe('90900000000000000');
+      expect(reduceCapacity('9999999999999999999')).toBe('9999899999999999999');
     });
 
     it('should not reduce capacity when the value is the same order of magnitude as the the buffer', () => {
-      expect(r('10000', 5)).toBe('10000');
-      expect(r('12345', 5)).toBe('12345');
-      expect(r('11000000000000000', 17)).toBe('11000000000000000');
+      expect(reduceCapacity('10000', 5)).toBe('10000');
+      expect(reduceCapacity('12345', 5)).toBe('12345');
+      expect(reduceCapacity('11000000000000000', 17)).toBe('11000000000000000');
     });
 
     it('should not reduce capacity when the value is smaller than the buffer', () => {
-      expect(r('1000', 15)).toBe('1000');
-      expect(r('123', 4)).toBe('123');
+      expect(reduceCapacity('1000', 15)).toBe('1000');
+      expect(reduceCapacity('123', 4)).toBe('123');
     });
   });
 });

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -43,37 +43,28 @@ describe('Helpers', () => {
       ]);
     });
 
-    it('should filter out the right number of edges with too small capacity', () => {
-      const edges = [
-        {
-          // Omit these fields here as the method does not check for them ..
-          // from: '0x0',
-          // to: '0x1',
-          // token: '0x0',
-          capacity: '2000000000000000',
-        },
-        {
-          capacity: '10000000000000',
-        },
-        {
-          capacity: '91000000000000000',
-        },
-        {
-          capacity: '4500000000000222',
-        },
+    it('should filter out the edges with too small capacity', () => {
+      const edgesRegular = [
+        // Omit these other fields here as the method does not use them
+        // from: '0x0',
+        // to: '0x1',
+        // token: '0x0',
+        { capacity: '2000000000000000' },
+        { capacity: '10000000000000' },
+        { capacity: '91000000000000000' },
+        { capacity: '4500000000000222' },
       ];
 
-      // Use default value
-      expect(reduceCapacities(edges).length).toBe(3);
-      expect(reduceCapacities(edges)).toEqual([
+      // default value
+      expect(reduceCapacities(edgesRegular)).toEqual([
         { capacity: '1900000000000000' },
         { capacity: '90900000000000000' },
         { capacity: '4400000000000222' },
       ]);
 
-      // .. and custom values
-      expect(reduceCapacities(edges, 17).length).toBe(0);
-      expect(reduceCapacities(edges, 2).length).toBe(4);
+      // custom values
+      expect(reduceCapacities(edgesRegular, 17).length).toBe(0);
+      expect(reduceCapacities(edgesRegular, 2).length).toBe(4);
 
       const edgesSmall = [
         { capacity: '9' },
@@ -87,17 +78,14 @@ describe('Helpers', () => {
         { capacity: '999' },
         { capacity: '9999' },
       ]);
-
       expect(reduceCapacities(edgesSmall, 2)).toEqual([
         { capacity: '990' },
         { capacity: '9990' },
       ]);
-
       expect(reduceCapacities(edgesSmall, 3)).toEqual([
         { capacity: '900' },
         { capacity: '9900' },
       ]);
-
       expect(reduceCapacities(edgesSmall, 4)).toEqual([{ capacity: '9000' }]);
       expect(reduceCapacities(edgesSmall, 5)).toEqual([]);
     });
@@ -108,7 +96,6 @@ describe('Helpers', () => {
       // Alias for better readability
       const r = reduceCapacity;
 
-      // Reduce the capacity correctly
       expect(r('10000', 1)).toBe('9999');
       expect(r('10000', 2)).toBe('9990');
       expect(r('10000', 3)).toBe('9900');
@@ -158,14 +145,16 @@ describe('Helpers', () => {
       // Using default value
       expect(r('17000000000000000')).toBe('16900000000000000');
       expect(r('91000000000000000')).toBe('90900000000000000');
-      expect(r('9900000000000000000')).toBe('9899900000000000000');
+      expect(r('9999999999999999999')).toBe('9899999999999999999');
+    });
 
-      // Do not do anything when value as large as the buffer
+    it('should not reduce capacity when the value is the same order of magnitude as the the buffer', () => {
       expect(r('10000', 5)).toBe('10000');
       expect(r('12345', 5)).toBe('12345');
-      expect(r('17000000000000000', 17)).toBe('17000000000000000');
+      expect(r('11000000000000000', 17)).toBe('11000000000000000');
+    });
 
-      // Do not do anything when value too short ..
+    it('should not reduce capacity when the value is smaller than the buffer', () => {
       expect(r('1000', 15)).toBe('1000');
       expect(r('123', 4)).toBe('123');
     });

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -93,67 +93,72 @@ describe('Helpers', () => {
 
   describe('reduceCapacity', () => {
     it('should reduce capacity values correctly', () => {
-      expect(reduceCapacity('10000', 1)).toBe('9999');
-      expect(reduceCapacity('10000', 2)).toBe('9990');
-      expect(reduceCapacity('10000', 3)).toBe('9900');
-      expect(reduceCapacity('10000', 4)).toBe('9000');
+      // Rename method here for better readability
+      const r = reduceCapacity;
 
-      expect(reduceCapacity('12345', 1)).toBe('12344');
-      expect(reduceCapacity('12345', 2)).toBe('12335');
-      expect(reduceCapacity('12345', 3)).toBe('12245');
-      expect(reduceCapacity('12345', 4)).toBe('11345');
+      expect(r('10000', 1)).toBe('9999');
+      expect(r('10000', 2)).toBe('9990');
+      expect(r('10000', 3)).toBe('9900');
+      expect(r('10000', 4)).toBe('9000');
 
-      expect(reduceCapacity('17000000000000000', 1)).toBe('16999999999999999');
-      expect(reduceCapacity('17000000000000000', 2)).toBe('16999999999999990');
-      expect(reduceCapacity('17000000000000000', 3)).toBe('16999999999999900');
-      expect(reduceCapacity('17000000000000000', 4)).toBe('16999999999999000');
-      expect(reduceCapacity('17000000000000000', 5)).toBe('16999999999990000');
-      expect(reduceCapacity('17000000000000000', 6)).toBe('16999999999900000');
-      expect(reduceCapacity('17000000000000000', 7)).toBe('16999999999000000');
-      expect(reduceCapacity('17000000000000000', 8)).toBe('16999999990000000');
-      expect(reduceCapacity('17000000000000000', 9)).toBe('16999999900000000');
-      expect(reduceCapacity('17000000000000000', 10)).toBe('16999999000000000');
-      expect(reduceCapacity('17000000000000000', 11)).toBe('16999990000000000');
-      expect(reduceCapacity('17000000000000000', 12)).toBe('16999900000000000');
-      expect(reduceCapacity('17000000000000000', 13)).toBe('16999000000000000');
-      expect(reduceCapacity('17000000000000000', 14)).toBe('16990000000000000');
-      expect(reduceCapacity('17000000000000000', 15)).toBe('16900000000000000');
-      expect(reduceCapacity('17000000000000000', 16)).toBe('16000000000000000');
+      expect(r('12345', 1)).toBe('12344');
+      expect(r('12345', 2)).toBe('12335');
+      expect(r('12345', 3)).toBe('12245');
+      expect(r('12345', 4)).toBe('11345');
 
-      expect(reduceCapacity('1094000000000012345', 1)).toBe('1094000000000012344');
-      expect(reduceCapacity('1094000000000012345', 2)).toBe('1094000000000012335');
-      expect(reduceCapacity('1094000000000012345', 3)).toBe('1094000000000012245');
-      expect(reduceCapacity('1094000000000012345', 4)).toBe('1094000000000011345');
-      expect(reduceCapacity('1094000000000012345', 5)).toBe('1094000000000002345');
-      expect(reduceCapacity('1094000000000012345', 6)).toBe('1093999999999912345');
-      expect(reduceCapacity('1094000000000012345', 7)).toBe('1093999999999012345');
-      expect(reduceCapacity('1094000000000012345', 8)).toBe('1093999999990012345');
-      expect(reduceCapacity('1094000000000012345', 9)).toBe('1093999999900012345');
-      expect(reduceCapacity('1094000000000012345', 10)).toBe('1093999999000012345');
-      expect(reduceCapacity('1094000000000012345', 11)).toBe('1093999990000012345');
-      expect(reduceCapacity('1094000000000012345', 12)).toBe('1093999900000012345');
-      expect(reduceCapacity('1094000000000012345', 13)).toBe('1093999000000012345');
-      expect(reduceCapacity('1094000000000012345', 14)).toBe('1093990000000012345');
-      expect(reduceCapacity('1094000000000012345', 15)).toBe('1093900000000012345');
-      expect(reduceCapacity('1094000000000012345', 16)).toBe('1093000000000012345');
-      expect(reduceCapacity('1094000000000012345', 17)).toBe('1084000000000012345');
-      expect(reduceCapacity('1094000000000012345', 18)).toBe('994000000000012345');
+      expect(r('17000000000000000', 1)).toBe('16999999999999999');
+      expect(r('17000000000000000', 2)).toBe('16999999999999990');
+      expect(r('17000000000000000', 3)).toBe('16999999999999900');
+      expect(r('17000000000000000', 4)).toBe('16999999999999000');
+      expect(r('17000000000000000', 5)).toBe('16999999999990000');
+      expect(r('17000000000000000', 6)).toBe('16999999999900000');
+      expect(r('17000000000000000', 7)).toBe('16999999999000000');
+      expect(r('17000000000000000', 8)).toBe('16999999990000000');
+      expect(r('17000000000000000', 9)).toBe('16999999900000000');
+      expect(r('17000000000000000', 10)).toBe('16999999000000000');
+      expect(r('17000000000000000', 11)).toBe('16999990000000000');
+     expect(r('17000000000000000', 12)).toBe('16999900000000000');
+      expect(r('17000000000000000', 13)).toBe('16999000000000000');
+      expect(r('17000000000000000', 14)).toBe('16990000000000000');
+      expect(r('17000000000000000', 15)).toBe('16900000000000000');
+      expect(r('17000000000000000', 16)).toBe('16000000000000000');
+
+      expect(r('1094000000000012345', 1)).toBe('1094000000000012344');
+      expect(r('1094000000000012345', 2)).toBe('1094000000000012335');
+      expect(r('1094000000000012345', 3)).toBe('1094000000000012245');
+      expect(r('1094000000000012345', 4)).toBe('1094000000000011345');
+      expect(r('1094000000000012345', 5)).toBe('1094000000000002345');
+      expect(r('1094000000000012345', 6)).toBe('1093999999999912345');
+      expect(r('1094000000000012345', 7)).toBe('1093999999999012345');
+      expect(r('1094000000000012345', 8)).toBe('1093999999990012345');
+      expect(r('1094000000000012345', 9)).toBe('1093999999900012345');
+      expect(r('1094000000000012345', 10)).toBe('1093999999000012345');
+      expect(r('1094000000000012345', 11)).toBe('1093999990000012345');
+      expect(r('1094000000000012345', 12)).toBe('1093999900000012345');
+      expect(r('1094000000000012345', 13)).toBe('1093999000000012345');
+      expect(r('1094000000000012345', 14)).toBe('1093990000000012345');
+      expect(r('1094000000000012345', 15)).toBe('1093900000000012345');
+      expect(r('1094000000000012345', 16)).toBe('1093000000000012345');
+      expect(r('1094000000000012345', 17)).toBe('1084000000000012345');
+      expect(r('1094000000000012345', 18)).toBe('994000000000012345');
 
       // Using default value
-      expect(reduceCapacity('17000000000000000')).toBe('16900000000000000');
-      expect(reduceCapacity('91000000000000000')).toBe('90900000000000000');
-      expect(reduceCapacity('9999999999999999999')).toBe('9999899999999999999');
+      expect(r('17000000000000000')).toBe('16900000000000000');
+      expect(r('91000000000000000')).toBe('90900000000000000');
+      expect(r('9999999999999999999')).toBe('9999899999999999999');
     });
 
     it('should not reduce capacity when the value is the same order of magnitude as the the buffer', () => {
-      expect(reduceCapacity('10000', 5)).toBe('10000');
-      expect(reduceCapacity('12345', 5)).toBe('12345');
-      expect(reduceCapacity('11000000000000000', 17)).toBe('11000000000000000');
+      expect(reduceCapacities('10000', 5)).toBe('10000');
+      expect(reduceCapacities('12345', 5)).toBe('12345');
+      expect(reduceCapacities('11000000000000000', 17)).toBe(
+        '11000000000000000',
+      );
     });
 
     it('should not reduce capacity when the value is smaller than the buffer', () => {
-      expect(reduceCapacity('1000', 15)).toBe('1000');
-      expect(reduceCapacity('123', 4)).toBe('123');
+      expect(reduceCapacities('1000', 15)).toBe('1000');
+      expect(reduceCapacities('123', 4)).toBe('123');
     });
   });
 });

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -23,6 +23,26 @@ describe('Helpers', () => {
   });
 
   describe('reduceCapacities', () => {
+    it('should preserve object fields', () => {
+      const edges = [
+        {
+          from: '0x0',
+          to: '0x1',
+          token: '0x3',
+          capacity: '1000',
+        },
+      ];
+
+      expect(reduceCapacities(edges, 3)).toEqual([
+        {
+          from: '0x0',
+          to: '0x1',
+          token: '0x3',
+          capacity: '900',
+        },
+      ]);
+    });
+
     it('should filter out the right number of edges with too small capacity', () => {
       const edges = [
         {
@@ -39,54 +59,115 @@ describe('Helpers', () => {
           capacity: '91000000000000000',
         },
         {
-          capacity: '2000000000000222',
+          capacity: '4500000000000222',
         },
       ];
 
+      // Use default value
       expect(reduceCapacities(edges).length).toBe(3);
+      expect(reduceCapacities(edges)).toEqual([
+        { capacity: '1900000000000000' },
+        { capacity: '90900000000000000' },
+        { capacity: '4400000000000222' },
+      ]);
+
+      // .. and custom values
       expect(reduceCapacities(edges, 17).length).toBe(0);
       expect(reduceCapacities(edges, 2).length).toBe(4);
 
       const edgesSmall = [
-        {
-          capacity: '1000',
-        },
-        {
-          capacity: '90',
-        },
-        {
-          capacity: '9',
-        },
-        {
-          capacity: '10000',
-        },
+        { capacity: '9' },
+        { capacity: '90' },
+        { capacity: '1000' },
+        { capacity: '10000' },
       ];
 
-      expect(reduceCapacities(edgesSmall, 1).length).toBe(3);
-      expect(reduceCapacities(edgesSmall, 2).length).toBe(2);
-      expect(reduceCapacities(edgesSmall, 3).length).toBe(2);
-      expect(reduceCapacities(edgesSmall, 4).length).toBe(1);
-      expect(reduceCapacities(edgesSmall, 5).length).toBe(0);
+      expect(reduceCapacities(edgesSmall, 1)).toEqual([
+        { capacity: '89' },
+        { capacity: '999' },
+        { capacity: '9999' },
+      ]);
+
+      expect(reduceCapacities(edgesSmall, 2)).toEqual([
+        { capacity: '990' },
+        { capacity: '9990' },
+      ]);
+
+      expect(reduceCapacities(edgesSmall, 3)).toEqual([
+        { capacity: '900' },
+        { capacity: '9900' },
+      ]);
+
+      expect(reduceCapacities(edgesSmall, 4)).toEqual([{ capacity: '9000' }]);
+      expect(reduceCapacities(edgesSmall, 5)).toEqual([]);
     });
   });
 
   describe('reduceCapacity', () => {
     it('should reduce capacity values correctly', () => {
+      // Alias for better readability
+      const r = reduceCapacity;
+
       // Reduce the capacity correctly
-      expect(reduceCapacity('17000000000000000')).toBe('16000000000000000');
-      expect(reduceCapacity('1094000000000012345')).toBe('1093000000000012345');
-      expect(reduceCapacity('9900000000000000000')).toBe('9899000000000000000');
+      expect(r('10000', 1)).toBe('9999');
+      expect(r('10000', 2)).toBe('9990');
+      expect(r('10000', 3)).toBe('9900');
+      expect(r('10000', 4)).toBe('9000');
 
-      // With custom buffer size ..
-      expect(reduceCapacity('9900000000000000000', 6)).toBe(
-        '9899999999999000000',
-      );
+      expect(r('12345', 1)).toBe('12344');
+      expect(r('12345', 2)).toBe('12335');
+      expect(r('12345', 3)).toBe('12245');
+      expect(r('12345', 4)).toBe('11345');
 
-      // As large as the buffer ..
-      expect(reduceCapacity('1000000000000000')).toBe('1000000000000000');
+      expect(r('17000000000000000', 1)).toBe('16999999999999999');
+      expect(r('17000000000000000', 2)).toBe('16999999999999990');
+      expect(r('17000000000000000', 3)).toBe('16999999999999900');
+      expect(r('17000000000000000', 4)).toBe('16999999999999000');
+      expect(r('17000000000000000', 5)).toBe('16999999999990000');
+      expect(r('17000000000000000', 6)).toBe('16999999999900000');
+      expect(r('17000000000000000', 7)).toBe('16999999999000000');
+      expect(r('17000000000000000', 8)).toBe('16999999990000000');
+      expect(r('17000000000000000', 9)).toBe('16999999900000000');
+      expect(r('17000000000000000', 10)).toBe('16999999000000000');
+      expect(r('17000000000000000', 11)).toBe('16999990000000000');
+      expect(r('17000000000000000', 12)).toBe('16999900000000000');
+      expect(r('17000000000000000', 13)).toBe('16999000000000000');
+      expect(r('17000000000000000', 14)).toBe('16990000000000000');
+      expect(r('17000000000000000', 15)).toBe('16900000000000000');
+      expect(r('17000000000000000', 16)).toBe('16000000000000000');
 
-      // Too short ..
-      expect(reduceCapacity('1000')).toBe('1000');
+      expect(r('1094000000000012345', 1)).toBe('1094000000000012344');
+      expect(r('1094000000000012345', 2)).toBe('1094000000000012335');
+      expect(r('1094000000000012345', 3)).toBe('1094000000000012245');
+      expect(r('1094000000000012345', 4)).toBe('1094000000000011345');
+      expect(r('1094000000000012345', 5)).toBe('1094000000000002345');
+      expect(r('1094000000000012345', 6)).toBe('1093999999999912345');
+      expect(r('1094000000000012345', 7)).toBe('1093999999999012345');
+      expect(r('1094000000000012345', 8)).toBe('1093999999990012345');
+      expect(r('1094000000000012345', 9)).toBe('1093999999900012345');
+      expect(r('1094000000000012345', 10)).toBe('1093999999000012345');
+      expect(r('1094000000000012345', 11)).toBe('1093999990000012345');
+      expect(r('1094000000000012345', 12)).toBe('1093999900000012345');
+      expect(r('1094000000000012345', 13)).toBe('1093999000000012345');
+      expect(r('1094000000000012345', 14)).toBe('1093990000000012345');
+      expect(r('1094000000000012345', 15)).toBe('1093900000000012345');
+      expect(r('1094000000000012345', 16)).toBe('1093000000000012345');
+      expect(r('1094000000000012345', 17)).toBe('1084000000000012345');
+      expect(r('1094000000000012345', 18)).toBe('994000000000012345');
+
+      // Using default value
+      expect(r('17000000000000000')).toBe('16900000000000000');
+      expect(r('91000000000000000')).toBe('90900000000000000');
+      expect(r('9900000000000000000')).toBe('9899900000000000000');
+
+      // Do not do anything when value as large as the buffer
+      expect(r('10000', 5)).toBe('10000');
+      expect(r('12345', 5)).toBe('12345');
+      expect(r('17000000000000000', 17)).toBe('17000000000000000');
+
+      // Do not do anything when value too short ..
+      expect(r('1000', 15)).toBe('1000');
+      expect(r('123', 4)).toBe('123');
     });
   });
 });


### PR DESCRIPTION
**Fixes**
- [x] `reduceCapacities` does not return array of edge objects but only the capacity strings
- [x] `reduceCapacities` overwrites values in the array instead of returning a new one
- [x] Decimals parameter is misleading
- [x] `reduceCapacities` removes edges wrongly