### PR TITLE
Run full sync task every week

### DIFF
--- a/src/services/edgesFromGraph.js
+++ b/src/services/edgesFromGraph.js
@@ -228,7 +228,6 @@ export function findEdgesInGraphData({ connections, safes, tokens }) {
             // special string comparison method as using BN instances affects
             // performance significantly
             const capacity = minNumberString(limit, balance);
-
             return (
               userAddress === token.safeAddress &&
               canSendToAddress === receiverSafeAddress &&
@@ -243,11 +242,10 @@ export function findEdgesInGraphData({ connections, safes, tokens }) {
             tokenOwner: token.safeAddress,
           });
         }
-
         return tokenAcc;
       },
+      []
     );
-
     // Merge all known data to get a list in the end containing what Token can
     // be sent to whom with what maximum value.
     trustedTokens.reduce((acc, trustedToken) => {
@@ -277,7 +275,7 @@ export function findEdgesInGraphData({ connections, safes, tokens }) {
       });
 
       return acc;
-    });
+    }, []);
   });
 
   // Add connections between token owners and the original safe of the token as

--- a/src/tasks/syncFullGraph.js
+++ b/src/tasks/syncFullGraph.js
@@ -48,8 +48,9 @@ async function rebuildTrustNetwork() {
     const endTime = performance.now();
     const milliseconds = Math.round(endTime - startTime);
 
+    const checkedEdges = Object.keys(edgeUpdateManager.checkedEdges).length;
     logger.info(
-      `Updated ${edges.length} edges with ${statistics.safes} safes, ${statistics.connections} connections and ${statistics.tokens} tokens (${milliseconds}ms)`,
+      `Updated ${checkedEdges} edges with ${statistics.safes} safes, ${statistics.connections} connections and ${statistics.tokens} tokens (${milliseconds}ms)`,
     );
   } catch (error) {
     logger.error(`Worker failed [${error.message}]`);

--- a/src/worker.js
+++ b/src/worker.js
@@ -15,7 +15,8 @@ import web3, {
 import { waitUntilGraphIsReady } from './services/graph';
 
 const CRON_NIGHTLY = '0 0 0 * * *';
-const CRON_WEEKLY = '0 0 0 * * 0';
+// CRON_WEEKLY: "At 12:00 on Friday".
+const CRON_WEEKLY = '0 0 12 * * 5';
 
 // Connect with postgres database
 db.authenticate()

--- a/src/worker.js
+++ b/src/worker.js
@@ -100,9 +100,9 @@ waitUntilGraphIsReady()
 
     // Run full sync every week
     submitJob(tasks.syncFullGraph, 'syncFullGraph-weekly', null, {
-      // repeat: {
-      //   cron: CRON_WEEKLY,
-      // },
+      repeat: {
+        cron: CRON_WEEKLY,
+      },
     });
 
     // Always write edges.json file on start to make sure it exists


### PR DESCRIPTION
This PR removes the environment variable flag (it was never really useful anyhow) and runs the *Full Sync Task* every Sunday at 12AM now. This task scrapes the whole Graph state and creates edges accordingly. It is very costly and might take 1-2 days to run, on the other hand we might recover from outages through this.