### PR TITLE
Update max size of the avatar image

### DIFF
--- a/src/middlewares/uploads.js
+++ b/src/middlewares/uploads.js
@@ -5,7 +5,7 @@ import multer, { MulterError } from 'multer';
 import APIError from '../helpers/errors';
 import web3 from '../services/web3';
 
-const DEFAULT_FILE_MAX_SIZE = 5 * 1000 * 1000;
+const DEFAULT_FILE_MAX_SIZE = 1 * 1000 * 1000;
 const DEFAULT_FILE_TYPES = ['jpeg', 'jpg', 'png'];
 
 function generateFileName(ext) {


### PR DESCRIPTION
The max file size for the avatar image is 1MB.
Missing:
* [ ] Testing the error message "File is too large" is propagated when trying to upload a file larger than the limit.
