### PR TITLE
Use last id instead of skip for pagination in graph queries with more…

### DIFF
--- a/src/services/edgesFromGraph.js
+++ b/src/services/edgesFromGraph.js
@@ -244,7 +244,7 @@ export function findEdgesInGraphData({ connections, safes, tokens }) {
         }
         return tokenAcc;
       },
-      []
+      [],
     );
     // Merge all known data to get a list in the end containing what Token can
     // be sent to whom with what maximum value.

--- a/src/worker.js
+++ b/src/worker.js
@@ -15,8 +15,8 @@ import web3, {
 import { waitUntilGraphIsReady } from './services/graph';
 
 const CRON_NIGHTLY = '0 0 0 * * *';
-// CRON_WEEKLY: "At 12:00 on Friday".
-const CRON_WEEKLY = '0 0 13 * * 5';
+// CRON_WEEKLY: "At 17:00 on Monday".
+const CRON_WEEKLY = '0 0 17 * * 1';
 
 // Connect with postgres database
 db.authenticate()


### PR DESCRIPTION
… than 5000 items in result.
The `skip` argument must be between 0 and 5000 (current limitations by TheGraph). Therefore, we sort the elements by id and reference the last element id for the next query.
This is needed to retrieve all the safes stored in the graph.