### PR TITLE
Debug graph errors

### DIFF
--- a/src/services/graph.js
+++ b/src/services/graph.js
@@ -1,5 +1,6 @@
 import fetch from 'isomorphic-fetch';
 
+import logger from '../helpers/logger';
 import loop from '../helpers/loop';
 import core from './core';
 
@@ -51,6 +52,10 @@ export async function fetchFromGraph(
     }
   }`;
   const data = await requestGraph(query);
+  if (!data) {
+    logger.error(`Error requesting graph with query: ${query}`)
+    return false;
+  }
   return data[name];
 }
 


### PR DESCRIPTION
The core doesn't propagate the error responses of the graph. With this code we see log the failing query.