### PR TITLE
Update queries and endpoints for graph-node v0.25.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ ETHEREUM_NODE_WS=ws://localhost:8545
 
 # Graph Node
 GRAPH_NODE_ENDPOINT=http://graph.circles.local
+GRAPH_NODE_INDEXING_STATUS_ENDPOINT=http://graph.circles.local:8030
 SUBGRAPH_NAME=CirclesUBI/circles-subgraph
 
 # Database


### PR DESCRIPTION
This update makes the `circles-api` compatible with the version v0.25.0 of the `graph-node` (https://github.com/CirclesUBI/circles-docker/pull/35).
- The indexing status port of the `graph-node` Docker image is 8030
- Update the graph queries for checking the latest block and the status of a subgraph