### PR TITLE
Update transitive transfer path

### DIFF
--- a/API.md
+++ b/API.md
@@ -43,6 +43,45 @@ Returns steps to transfer transitively through trust graph from one node to anot
 - `400` Parameters missing or malformed
 - `422` Invalid transfer
 
+### Update transitive transfer steps
+
+Updates the steps of a transitive transfer.
+
+**Request:**
+
+`POST /api/transfers/update`
+
+**Parameters:**
+
+```
+{
+  from: <string>,
+  to: <string>,
+  value: <number>,
+}
+```
+
+- `from`: Sender address
+- `to`: Receiver address
+- `value`: Amount of Freckles intended to be sent between sender and receiver (the fractional monetary unit of Circles is named Freckles. One Circle = 1,000,000,000,000,000,000 Freckles (10<sup>18</sup>))
+
+**Response:**
+
+```
+{
+  status: 'ok',
+  data: {
+    updated: <boolean>
+  }
+}
+```
+
+- `updated`: Whether all the steps have been successfully updated
+
+**Errors:**
+
+- `400` Parameters missing or malformed
+
 ### Store transfer meta data
 
 Stores meta data like payment note connected to a made transfer. This data is only readable for sender or receiver of that transaction.

--- a/src/controllers/transfers.js
+++ b/src/controllers/transfers.js
@@ -3,6 +3,7 @@ import httpStatus from 'http-status';
 import APIError from '../helpers/errors';
 import Transfer from '../models/transfers';
 import transferSteps from '../services/findTransferSteps';
+import updatePath from '../services/updateTransferSteps';
 import { checkFileExists } from '../services/edgesFile';
 import { checkSignature } from '../helpers/signature';
 import { requestGraph } from '../services/graph';
@@ -126,6 +127,27 @@ export default {
 
     try {
       const result = await transferSteps({
+        ...req.body,
+      });
+
+      respondWithSuccess(res, result);
+    } catch (error) {
+      next(new APIError(httpStatus.UNPROCESSABLE_ENTITY, error.message));
+    }
+  },
+
+  updateTransferSteps: async (req, res, next) => {
+    if (!checkFileExists()) {
+      next(
+        new APIError(
+          httpStatus.SERVICE_UNAVAILABLE,
+          'Trust network file does not exist',
+        ),
+      );
+    }
+
+    try {
+      const result = await updatePath({
         ...req.body,
       });
 

--- a/src/helpers/loop.js
+++ b/src/helpers/loop.js
@@ -10,7 +10,7 @@ export default async function loop(request, condition) {
         const response = await request();
         attempt += 1;
 
-        if (await condition(response)) {
+        if (condition(response)) {
           clearInterval(interval);
           resolve(response);
         } else if (attempt > MAX_ATTEMPTS) {

--- a/src/routes/transfers.js
+++ b/src/routes/transfers.js
@@ -13,6 +13,12 @@ router.put(
 );
 
 router.post(
+  '/update',
+  validate(transfersValidation.findTransferSteps),
+  transfersController.updateTransferSteps,
+);
+
+router.post(
   '/:transactionHash',
   validate(transfersValidation.getByTransactionHash),
   transfersController.getByTransactionHash,

--- a/src/services/findTransferSteps.js
+++ b/src/services/findTransferSteps.js
@@ -1,83 +1,9 @@
-import HubContract from 'circles-contracts/build/contracts/Hub.json';
-import TokenContract from 'circles-contracts/build/contracts/Token.json';
 import findTransferSteps from '@circles/transfer';
 import { performance } from 'perf_hooks';
 
-import web3 from './web3';
-import EdgeUpdateManager from './edgesUpdate';
-import tasks from '../tasks';
-import submitJob from '../tasks/submitJob';
-import { minNumberString } from '../helpers/compare';
-import loop from '../helpers/loop';
 import { EDGES_FILE_PATH, PATHFINDER_FILE_PATH } from '../constants';
 
 const DEFAULT_PROCESS_TIMEOUT = 1000 * 60;
-
-const hubContract = new web3.eth.Contract(
-  HubContract.abi,
-  process.env.HUB_ADDRESS,
-);
-
-async function isStepValid(
-  tokenAddress,
-  tokenOwner,
-  sender,
-  receiver,
-  plannedLimit,
-) {
-  // Get send limit
-  const limit = await hubContract.methods
-    .checkSendLimit(tokenOwner, sender, receiver)
-    .call();
-  // Get Token balance
-  const tokenContract = new web3.eth.Contract(TokenContract.abi, tokenAddress);
-  const balance = await tokenContract.methods.balanceOf(sender).call();
-  // The capacity is the minimum between the sendLimit and the balance
-  const capacity = minNumberString(limit, balance);
-  return web3.utils.toBN(plannedLimit).lte(web3.utils.toBN(capacity));
-}
-
-// Checks that all the transfer steps are valid. Invalid steps are updated
-async function checkValidTransferSteps(result) {
-  const edgeUpdateManager = new EdgeUpdateManager();
-
-  const values = await Promise.allSettled(
-    result.transferSteps.map(async (step) => {
-      const tokenAddress = await hubContract.methods
-        .userToToken(step.token)
-        .call();
-      const stepValid = await isStepValid(
-        tokenAddress,
-        step.token,
-        step.from,
-        step.to,
-        step.value,
-      );
-      if (!stepValid) {
-        // Update the edge
-        await edgeUpdateManager.updateEdge(
-          {
-            token: step.token,
-            from: step.from,
-            to: step.to,
-          },
-          tokenAddress,
-        );
-      }
-      return stepValid;
-    }),
-  );
-
-  const areStepsValid = values.every(
-    (step) => step.status === 'fulfilled' && step.value == true,
-  );
-
-  if (!areStepsValid) {
-    // Write edges.json file to update edges
-    submitJob(tasks.exportEdges, 'exportEdges-findTransferSteps');
-  }
-  return areStepsValid;
-}
 
 export default async function transferSteps({ from, to, value }) {
   if (from === to) {
@@ -89,23 +15,16 @@ export default async function transferSteps({ from, to, value }) {
     ? parseInt(process.env.TRANSFER_STEPS_TIMEOUT, 10)
     : DEFAULT_PROCESS_TIMEOUT;
 
-  const result = await loop(
-    async () => {
-      return await findTransferSteps(
-        {
-          from,
-          to,
-          value,
-        },
-        {
-          edgesFile: EDGES_FILE_PATH,
-          pathfinderExecutable: PATHFINDER_FILE_PATH,
-          timeout,
-        },
-      );
+  const result = await findTransferSteps(
+    {
+      from,
+      to,
+      value,
     },
-    async (data) => {
-      return await checkValidTransferSteps(data);
+    {
+      edgesFile: EDGES_FILE_PATH,
+      pathfinderExecutable: PATHFINDER_FILE_PATH,
+      timeout,
     },
   );
 

--- a/src/services/updateTransferSteps.js
+++ b/src/services/updateTransferSteps.js
@@ -42,31 +42,32 @@ async function updateSteps(result) {
   // Write edges.json file to update edges
   submitJob(tasks.exportEdges, 'exportEdges-findTransferSteps');
 
-  return values.every(
-    (step) => step.status === 'fulfilled',
-  );
+  return values.every((step) => step.status === 'fulfilled');
 }
 
 export default async function updatePath({ from, to, value }) {
-
   const timeout = process.env.TRANSFER_STEPS_TIMEOUT
     ? parseInt(process.env.TRANSFER_STEPS_TIMEOUT, 10)
     : DEFAULT_PROCESS_TIMEOUT;
 
   try {
-    return { updated: await updateSteps(await findTransferSteps(
-      {
-        from,
-        to,
-        value,
-      },
-      {
-        edgesFile: EDGES_FILE_PATH,
-        pathfinderExecutable: PATHFINDER_FILE_PATH,
-        timeout,
-      },
-    ))};
-  } catch (error){
+    return {
+      updated: await updateSteps(
+        await findTransferSteps(
+          {
+            from,
+            to,
+            value,
+          },
+          {
+            edgesFile: EDGES_FILE_PATH,
+            pathfinderExecutable: PATHFINDER_FILE_PATH,
+            timeout,
+          },
+        ),
+      ),
+    };
+  } catch (error) {
     logger.error(`Error updating steps [${error.message}]`);
     throw error;
   }

--- a/src/services/updateTransferSteps.js
+++ b/src/services/updateTransferSteps.js
@@ -1,0 +1,73 @@
+import HubContract from 'circles-contracts/build/contracts/Hub.json';
+import findTransferSteps from '@circles/transfer';
+
+import web3 from './web3';
+import EdgeUpdateManager from './edgesUpdate';
+import logger from '../helpers/logger';
+import tasks from '../tasks';
+import submitJob from '../tasks/submitJob';
+import { EDGES_FILE_PATH, PATHFINDER_FILE_PATH } from '../constants';
+
+const DEFAULT_PROCESS_TIMEOUT = 1000 * 60;
+
+const hubContract = new web3.eth.Contract(
+  HubContract.abi,
+  process.env.HUB_ADDRESS,
+);
+
+// All the steps are updated
+async function updateSteps(result) {
+  const edgeUpdateManager = new EdgeUpdateManager();
+
+  const values = await Promise.allSettled(
+    result.transferSteps.map(async (step) => {
+      const tokenAddress = await hubContract.methods
+        .userToToken(step.token)
+        .call();
+
+      // Update the edge
+      await edgeUpdateManager.updateEdge(
+        {
+          token: step.token,
+          from: step.from,
+          to: step.to,
+        },
+        tokenAddress,
+      );
+
+      return true;
+    }),
+  );
+
+  // Write edges.json file to update edges
+  submitJob(tasks.exportEdges, 'exportEdges-findTransferSteps');
+
+  return values.every(
+    (step) => step.status === 'fulfilled',
+  );
+}
+
+export default async function updatePath({ from, to, value }) {
+
+  const timeout = process.env.TRANSFER_STEPS_TIMEOUT
+    ? parseInt(process.env.TRANSFER_STEPS_TIMEOUT, 10)
+    : DEFAULT_PROCESS_TIMEOUT;
+
+  try {
+    return await updateSteps(await findTransferSteps(
+      {
+        from,
+        to,
+        value,
+      },
+      {
+        edgesFile: EDGES_FILE_PATH,
+        pathfinderExecutable: PATHFINDER_FILE_PATH,
+        timeout,
+      },
+    ));
+  } catch (error){
+    logger.error(`Error updating steps [${error.message}]`);
+    throw error;
+  }
+}

--- a/src/services/updateTransferSteps.js
+++ b/src/services/updateTransferSteps.js
@@ -54,7 +54,7 @@ export default async function updatePath({ from, to, value }) {
     : DEFAULT_PROCESS_TIMEOUT;
 
   try {
-    return await updateSteps(await findTransferSteps(
+    return { updated: await updateSteps(await findTransferSteps(
       {
         from,
         to,
@@ -65,7 +65,7 @@ export default async function updatePath({ from, to, value }) {
         pathfinderExecutable: PATHFINDER_FILE_PATH,
         timeout,
       },
-    ));
+    ))};
   } catch (error){
     logger.error(`Error updating steps [${error.message}]`);
     throw error;

--- a/test/transfers-update-steps.test.js
+++ b/test/transfers-update-steps.test.js
@@ -1,0 +1,25 @@
+import httpStatus from 'http-status';
+import request from 'supertest';
+
+import { mockGraphSafes } from './utils/mocks';
+import { randomChecksumAddress } from './utils/common';
+
+import app from '~';
+
+describe('POST /transfers/update - Update transfer steps', () => {
+  beforeAll(async () => {
+    mockGraphSafes();
+  });
+
+  it('should return an error when value is not positive', async () => {
+    await request(app)
+      .post('/api/transfers/update')
+      .send({
+        from: randomChecksumAddress(),
+        to: randomChecksumAddress(),
+        value: 0,
+      })
+      .set('Accept', 'application/json')
+      .expect(httpStatus.BAD_REQUEST);
+  });
+});


### PR DESCRIPTION
Create a new route `api/transfers/update` which updates the transfer steps given the transitive transfer params `{from, to, value}`.
Furthermore, it removes the functionality of "Check transfer steps before returning them" (https://github.com/CirclesUBI/circles-api/pull/103) from the `findTransferSteps` service, and placing it in a new service `updateTransferSteps`.