### PR TITLE
Fix gh action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,7 +45,8 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-
+      - name: Setup env file
+        run: cp .env.example .env
       - run: npm run db:migrate
       - run: npm run db:seed
       - run: npm test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       SAFE_DEFAULT_CALLBACK_HANDLER: '0x67B5656d60a809915323Bf2C40A8bEF15A152e3e'
       API_SERVICE_ENDPOINT: http://api.circles.local
       GRAPH_NODE_ENDPOINT: http://graph.circles.local
-      SUBGRAPH_NAME: CirclesUBI/circles-subgraph
+      SUBGRAPH_NAME: circlesubi/circles-subgraph
       ETHEREUM_NODE_WS: ws://localhost:8545
       DATABASE_SOURCE: graph
     services:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Read node version from .nvmrc
         id: nvmrc
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: Setup node
         uses: actions/setup-node@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,14 +31,14 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Read node version from .nvmrc
         id: nvmrc
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'npm'
           node-version: '${{ steps.nvmrc.outputs.NODE_VERSION }}'

--- a/.github/workflows/tagbuild.yml
+++ b/.github/workflows/tagbuild.yml
@@ -27,19 +27,19 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get ref
         id: parse_ref
         run: |
-          echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
+          echo "tag=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Digital Ocean Registry login
         run: |
           doctl registry login
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true

--- a/.github/workflows/tagbuild.yml
+++ b/.github/workflows/tagbuild.yml
@@ -21,7 +21,7 @@ jobs:
           doctl auth init -t ${{ secrets.CIRCLES_CI_DO_TOKEN }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ An offchain API service to safely store and resolve [`Circles`] user data from p
 
 ## Requirements
 
-- NodeJS environment (tested with v12 and v14)
+- NodeJS environment (tested with v14)
 - PostgreSQL database
 - Redis
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20607,8 +20607,7 @@
         "app-module-path": "^2.2.0",
         "ganache": "7.4.0",
         "mocha": "9.2.2",
-        "original-require": "^1.0.1",
-        "solc": "^0.5.14"
+        "original-require": "^1.0.1"
       }
     },
     "tslib": {


### PR DESCRIPTION
Update GH Actions with:

- Remove deprecated command `set-output`: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples
- Update to setup-node@v3
- Update to docker/login-action@v2
- Update to docker/build-push-action@v3
- Update subgraph name variable
- Add missing step: setup .env file