### PR TITLE
Add delete Avatar Image endpoint

### DIFF
--- a/src/controllers/uploads.js
+++ b/src/controllers/uploads.js
@@ -1,11 +1,14 @@
-import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import httpStatus from 'http-status';
 import mime from 'mime';
 
 import APIError from '../helpers/errors';
+import User from '../models/users';
 import { FIELD_NAME } from '../routes/uploads';
-import { respondWithSuccess } from '../helpers/responses';
-import { s3 } from '../services/aws';
+import { respondWithSuccess, respondWithError } from '../helpers/responses';
+import { s3, AWS_S3_DOMAIN } from '../services/aws';
+
+export const KEY_PATH = 'uploads/avatars/';
 
 export default {
   uploadAvatarImage: async (req, res, next) => {
@@ -23,7 +26,7 @@ export default {
       }
 
       const { buffer, fileName, fileType } = req.locals.images[FIELD_NAME][0];
-      const key = `uploads/avatars/${fileName}`;
+      const key = `${KEY_PATH}${fileName}`;
 
       const params = {
         Bucket: bucket, // The name of the bucket.
@@ -37,12 +40,55 @@ export default {
       respondWithSuccess(
         res,
         {
-          url: `https://${bucket}.s3.amazonaws.com/${key}`,
+          url: `https://${bucket}.${AWS_S3_DOMAIN}/${key}`,
           fileName,
           fileType,
         },
         results.$metadata.httpStatusCode,
       );
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  deleteAvatarImage: async (req, res, next) => {
+    const bucket = process.env.AWS_S3_BUCKET;
+    try {
+      const { url } = req.body;
+      const imageUrl = new URL(url);
+      if (
+        imageUrl.host != `${bucket}.${AWS_S3_DOMAIN}` ||
+        !imageUrl.pathname.startsWith(`/${KEY_PATH}`)
+      ) {
+        respondWithError(res, {}, httpStatus.BAD_REQUEST);
+      } else {
+        // Check that the url is not used in the users db
+        const avatarExists = await User.findOne({
+          where: {
+            avatarUrl: url,
+          },
+        });
+        if (!avatarExists) {
+          const pathSplit = imageUrl.pathname.split('/');
+          const fileName = pathSplit[pathSplit.length - 1];
+          const key = `${KEY_PATH}${fileName}`;
+          const params = {
+            Bucket: bucket, // The name of the bucket.
+            Key: key, // The name of the object.
+          };
+          const results = await s3.send(new DeleteObjectCommand(params));
+          respondWithSuccess(
+            res,
+            { avatarUrlIsUsed: false },
+            results.$metadata.httpStatusCode,
+          );
+        } else {
+          respondWithSuccess(
+            res,
+            { avatarUrlIsUsed: true }, // the avatar image cannot be deleted because is used by an user entry
+          );
+        }
+      }
     } catch (error) {
       next(error);
     }

--- a/src/controllers/uploads.js
+++ b/src/controllers/uploads.js
@@ -68,7 +68,9 @@ export default {
             avatarUrl: url,
           },
         });
-        if (!avatarExists) {
+        if (avatarExists) {
+          respondWithError(res, {}, httpStatus.UNPROCESSABLE_ENTITY);
+        } else {
           const pathSplit = imageUrl.pathname.split('/');
           const fileName = pathSplit[pathSplit.length - 1];
           const key = `${KEY_PATH}${fileName}`;
@@ -77,16 +79,7 @@ export default {
             Key: key, // The name of the object.
           };
           const results = await s3.send(new DeleteObjectCommand(params));
-          respondWithSuccess(
-            res,
-            { avatarUrlIsUsed: false },
-            results.$metadata.httpStatusCode,
-          );
-        } else {
-          respondWithSuccess(
-            res,
-            { avatarUrlIsUsed: true }, // the avatar image cannot be deleted because is used by an user entry
-          );
+          respondWithSuccess(res, {}, results.$metadata.httpStatusCode);
         }
       }
     } catch (error) {

--- a/src/routes/uploads.js
+++ b/src/routes/uploads.js
@@ -3,6 +3,8 @@ import express from 'express';
 import uploadsController from '../controllers/uploads';
 import uploadFilesMiddleware from '../middlewares/uploads';
 import convertImagesMiddleware from '../middlewares/images';
+import uploadsValidation from '../validations/uploads';
+import validate from '../helpers/validate';
 
 export const FIELD_NAME = 'files';
 
@@ -29,6 +31,12 @@ router.post(
     },
   ]),
   uploadsController.uploadAvatarImage,
+);
+
+router.delete(
+  '/avatar',
+  validate(uploadsValidation.deleteAvatarImage),
+  uploadsController.deleteAvatarImage,
 );
 
 export default router;

--- a/src/services/aws.js
+++ b/src/services/aws.js
@@ -1,6 +1,9 @@
 import { S3 } from '@aws-sdk/client-s3';
+
 const REGION = process.env.AWS_REGION || 'eu-central-1';
 
 const s3 = new S3({ region: REGION });
+
+export const AWS_S3_DOMAIN = 's3.amazonaws.com';
 
 export { s3 };

--- a/src/validations/uploads.js
+++ b/src/validations/uploads.js
@@ -1,0 +1,11 @@
+import { Joi } from 'celebrate';
+
+export default {
+  deleteAvatarImage: {
+    body: Joi.object({
+      url: Joi.string()
+        .uri({ scheme: ['http', 'https'] })
+        .required(),
+    }),
+  },
+};

--- a/test/aws-validation.test.js
+++ b/test/aws-validation.test.js
@@ -1,0 +1,46 @@
+import httpStatus from 'http-status';
+import request from 'supertest';
+import app from '~';
+import { AWS_S3_DOMAIN } from '~/services/aws';
+import { KEY_PATH } from '~/controllers/uploads';
+
+async function expectErrorStatus(body, status = httpStatus.BAD_REQUEST) {
+  return await request(app)
+    .delete('/api/uploads/avatar')
+    .send(body)
+    .expect(status);
+}
+
+describe('AWS', () => {
+  describe('delete object with validation', () => {
+    it('validate uri', async () => {
+      const bucket = process.env.AWS_S3_BUCKET;
+      // Missing fields
+      await expectErrorStatus({});
+      // Wrong fields
+      await expectErrorStatus({
+        name: 'kaka',
+      });
+      // Empty url
+      await expectErrorStatus({
+        url: '',
+      });
+      // Null url
+      await expectErrorStatus({
+        url: null,
+      });
+      // Invalid uri protocol
+      await expectErrorStatus({
+        url: 'git://miau.com',
+      });
+      // Invalid uri domain
+      await expectErrorStatus({
+        url: `https://${bucket}.s3.amazonaws.miau/${KEY_PATH}kaka.jpg`,
+      });
+      // Invalid pathname
+      await expectErrorStatus({
+        url: `https://${bucket}.${AWS_S3_DOMAIN}/downloads/avatars/kaka.jpg`,
+      });
+    });
+  });
+});


### PR DESCRIPTION
A new endpoint is created for deleting the avatar image if the url is well formatted and the url is not used as `avatarUrl` in the Users db table.

Closes https://github.com/CirclesUBI/circles-api/issues/127